### PR TITLE
Add aliases for several ChezScheme-variant binaries

### DIFF
--- a/plt-make-links.sh
+++ b/plt-make-links.sh
@@ -8,7 +8,8 @@ NAMES="drracket mred mzpp pdf-slatex plt-r5rs racket
        scribble slideshow gracket mred-text mzscheme
        plt-games plt-r6rs racket-package-manager setup-plt
        swindle gracket-text mzc mztext plt-help plt-web-server
-       raco slatex"
+       raco slatex
+       racketcs racocs scribblecs gracketcs racket-documentationcs"
 
 read -e -p "Where is the plt-bin script located? (default: $PLT_BIN_DEFAULT)" PLT_BIN
 PLT_BIN=${PLT_BIN:-$PLT_BIN_DEFAULT}


### PR DESCRIPTION
Also generate aliases for `racketcs`, `racocs`, `scribblecs`, `gracketcs` and `racket-documentationcs`.